### PR TITLE
refactor to support python 3

### DIFF
--- a/examples/01-parallel_krhf.py
+++ b/examples/01-parallel_krhf.py
@@ -45,5 +45,5 @@ print(mf.scf())
 # Similar replacement can be placed on MDF module
 #
 mf.with_df = df.MDF(cell, kpts)
-print mf.scf()
+print(mf.scf())
 

--- a/pbc/df/aft.py
+++ b/pbc/df/aft.py
@@ -90,7 +90,7 @@ def _int_nuc_vloc(mydf, nuccell, kpts, intor='cint3c2e_sph'):
         c_shls_slice = (ctypes.c_int*6)(0, cell.nbas, cell.nbas, cell.nbas*2,
                                         cell.nbas*2+atm0, cell.nbas*2+atm1)
 
-        for l in mpi.static_partition(range(len(Ls))):
+        for l in mpi.static_partition(list(range(len(Ls)))):
             L1 = Ls[l]
             env[ptr_coordL] = xyz + L1
             exp_Lk = numpy.einsum('k,ik->ik', expLk[l].conj(), expLk[:l+1])

--- a/pbc/df/aft_ao2mo.py
+++ b/pbc/df/aft_ao2mo.py
@@ -47,4 +47,4 @@ if __name__ == '__main__':
     eri0 = numpy.einsum('ijpl,pk->ijkl', eri0, mo.conj())
     eri0 = numpy.einsum('ijkp,pl->ijkl', eri0, mo       )
     eri1 = with_df.ao2mo(mo, kpts)
-    print abs(eri1.reshape(eri0.shape)-eri0).sum()
+    print(abs(eri1.reshape(eri0.shape)-eri0).sum())

--- a/pbc/df/df_ao2mo.py
+++ b/pbc/df/df_ao2mo.py
@@ -47,4 +47,4 @@ if __name__ == '__main__':
     eri0 = numpy.einsum('ijpl,pk->ijkl', eri0, mo.conj())
     eri0 = numpy.einsum('ijkp,pl->ijkl', eri0, mo       )
     eri1 = with_df.ao2mo(mo, kpts)
-    print abs(eri1.reshape(eri0.shape)-eri0).sum()
+    print(abs(eri1.reshape(eri0.shape)-eri0).sum())

--- a/pbc/df/fft.py
+++ b/pbc/df/fft.py
@@ -194,7 +194,7 @@ class FFTDF(fft.FFTDF):
             ni.non0tab = ni.make_mask(cell, coords)
         if kpts_band is None:
             aoR = ni.eval_ao(cell, coords, kpts, non0tab=ni.non0tab)
-            for k in mpi.static_partition(range(len(kpts))):
+            for k in mpi.static_partition(list(range(len(kpts)))):
                 yield k, aoR[k]
         else:
             aoR = ni.eval_ao(cell, coords, kpts_band, non0tab=ni.non0tab)
@@ -204,7 +204,7 @@ class FFTDF(fft.FFTDF):
                 else:
                     return
             else:
-                for k in mpi.static_partition(range(len(kpts_band))):
+                for k in mpi.static_partition(list(range(len(kpts_band)))):
                     yield k, aoR[k]
 
     get_pp = get_pp

--- a/pbc/df/mdf_ao2mo.py
+++ b/pbc/df/mdf_ao2mo.py
@@ -47,4 +47,4 @@ if __name__ == '__main__':
     eri0 = numpy.einsum('ijpl,pk->ijkl', eri0, mo.conj())
     eri0 = numpy.einsum('ijkp,pl->ijkl', eri0, mo       )
     eri1 = with_df.ao2mo(mo, kpts)
-    print abs(eri1.reshape(eri0.shape)-eri0).sum()
+    print(abs(eri1.reshape(eri0.shape)-eri0).sum())

--- a/tools/mpi_pool.py
+++ b/tools/mpi_pool.py
@@ -161,7 +161,11 @@ class _close_pool_message(object):
 class _function_wrapper(object):
     def __init__(self, function):
         #print(function.__closure__)
-        self.func_code = marshal.dumps(function.func_code)
+        if sys.version_info >= (3, 0):
+            code = function.__code__
+        else:
+            code = function.func_code
+        self.func_code = marshal.dumps(code)
 
 def _error_function(task):
     raise RuntimeError("Pool was sent tasks before being told what "


### PR DESCRIPTION
Makes the code compatible with python 3. I'm not sure if you want to support also python 2 with this module, but it already had multiple print() calls without importing the future module. If so, I can add the future imports.